### PR TITLE
added spi port selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ def on_recv(payload):
     print("Received:", payload.message)
     print("RSSI: {}; SNR: {}".format(payload.rssi, payload.snr))
 
-# Use chip select 1. GPIO pin 5 will be used for interrupts and set reset pin to 25
+# Lora object will use spi port 0 and use chip select 1. GPIO pin 5 will be used for interrupts and set reset pin to 25
 # The address of this device will be set to 2
-lora = LoRa(1, 5, 2, reset_pin = 25, modem_config=ModemConfig.Bw125Cr45Sf128, tx_power=14, acks=True)
+lora = LoRa(0, 1, 5, 2, reset_pin = 25, modem_config=ModemConfig.Bw125Cr45Sf128, tx_power=14, acks=True)
 lora.on_recv = on_recv
 
 # Send a message to a recipient device with address 10
@@ -86,9 +86,11 @@ lora = LoRa(0, 17, 2, crypto=crypto)
 ### Configuration
 ##### Initialization
 ```python
-LoRa(channel, interrupt, this_address, reset_pin=reset_pin, freq=915, tx_power=14,
+LoRa(spiport, channel, interrupt, this_address, reset_pin=reset_pin, freq=915, tx_power=14,
       modem_config=ModemConfig.Bw125Cr45Sf128, acks=False, crypto=None)
 ```
+**`spiport`** SPI interface to use (either 0 or 1, if your LoRa radio if connected to SPI0 or SPI1, respectively)
+
 **`channel`** SPI channel to use (either 0 or 1, if your LoRa radio if connected to CE0 or CE1, respectively)
 
 **`interrupt`** GPIO pin (BCM-style numbering) to use for the interrupt

--- a/pyLoraRFM9x/lora.py
+++ b/pyLoraRFM9x/lora.py
@@ -20,13 +20,14 @@ class ModemConfig(Enum):
 
 
 class LoRa(object):
-    def __init__(self, channel, interrupt, this_address, reset_pin=None, freq=915, tx_power=14,
+    def __init__(self, spiport, channel, interrupt, this_address, reset_pin=None, freq=915, tx_power=14,
                  modem_config=ModemConfig.Bw125Cr45Sf128, receive_all=False,
                  acks=False, crypto=None):
         """
-        Lora((channel, interrupt, this_address, freq=915, tx_power=14,
+        Lora((spiport, channel, interrupt, this_address, freq=915, tx_power=14,
                  modem_config=ModemConfig.Bw125Cr45Sf128, receive_all=False,
                  acks=False, crypto=None, reset_pin=False)
+        spiport: spi port connected to module, 1 or 0
         channel: SPI channel [0 for CE0, 1 for CE1]
         interrupt: Raspberry Pi interrupt pin (BCM)
         this_address: set address for this device [0-254]
@@ -40,7 +41,7 @@ class LoRa(object):
         """
             
 
-        
+        self._spiport = spiport
         self._channel = channel
         self._interrupt = interrupt
         self._hw_lock = threading.RLock() # lock for multithreaded access
@@ -79,7 +80,7 @@ class LoRa(object):
 
         
         self.spi = spidev.SpiDev()
-        self.spi.open(0, self._channel)
+        self.spi.open(spiport, self._channel)
         self.spi.max_speed_hz = 5000000
 
         self._spi_write(REG_01_OP_MODE, MODE_SLEEP | LONG_RANGE_MODE)


### PR DESCRIPTION
You can decide during initi wich spi port to use instead of forcing only default SPI0, useful in case of boards with multiple SPI ports