### PR TITLE
Fix GPIO clean up issue

### DIFF
--- a/pyLoraRFM9x/lora.py
+++ b/pyLoraRFM9x/lora.py
@@ -379,7 +379,7 @@ class LoRa(object):
         self._spi_write(REG_12_IRQ_FLAGS, 0xff)
 
     def close(self):
-        GPIO.cleanup()
+        lgpio.gpiochip_close(0)
         self.spi.close()
 
     def __del__(self):


### PR DESCRIPTION
GPIO.close does not exist in lgpio, likely an accident from switching over from RPI.GPIO